### PR TITLE
Scratch CI using GitHub actions: lint & test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: Lint & Test Go code
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
+
+jobs:
+  lint:
+    # Fresh golangci-lint wont work on Windows
+    runs-on: ubuntu-latest
+    container: dockercore/golang-cross
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    # Someday we'll switch to official action, but right now we depend on CGO Windows-specific stuff
+    - name: Install golangci-lint
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -d -b $(go env GOPATH)/bin v1.27.0
+
+    - name: Lint the code
+      run: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        bash ./build/lint.sh
+
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Test the code
+        run: bash ./build/test.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # etw
 [![GoDev](https://img.shields.io/static/v1?label=godev&message=reference&color=00add8)](https://pkg.go.dev/github.com/bi-zone/etw)
 [![Go Report Card](https://goreportcard.com/badge/github.com/bi-zone/etw)](https://goreportcard.com/report/github.com/bi-zone/etw)
+![Lint & Test Go code](https://github.com/bi-zone/etw/workflows/Lint%20&%20Test%20Go%20code/badge.svg)
 

--- a/build/.golangci.yml
+++ b/build/.golangci.yml
@@ -1,5 +1,4 @@
 run:
-  concurrency: 4
   deadline: 10m
   issues-exit-code: 1
 
@@ -10,3 +9,8 @@ linters:
     - godox
     - wsl
     - gomnd
+
+issues:
+  exclude:
+    # Sometimes goerr113 is too annoying
+    - do not define dynamic errors, use wrapped static errors instead

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+export PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+ARGS=("$@")
+
+# shellcheck source=build/vars.sh
+source "${PROJECT_ROOT}/build/vars.sh"
+
+# We are using go modules, so tests should be run from go.mod directory.
+cd "${PROJECT_ROOT}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Testing go code on $(go version)"
+
+esc=$(printf '\033') # Red color
+go test \
+  -v \
+  --timeout 10m \
+  --cover -coverprofile="${TMPDIR}/coverage.out" \
+  "${ARGS[@]}" \
+  ./... | sed "s,FAIL.*,${esc}[31m&${esc}[0m," # Colorize fails
+
+# Check return code of the go test, not sed.
+GOEXIT=${PIPESTATUS[0]}
+if [[ "${GOEXIT}" != "0" ]]; then
+  exit "${GOEXIT}"
+fi
+
+go tool cover -func "${TMPDIR}/coverage.out" | grep total
+
+echo "Everything is ok"

--- a/session.go
+++ b/session.go
@@ -93,6 +93,8 @@ func (s *Session) Process(cb EventCallback) error {
 // - WithLevel(lvl TraceLevel)
 // - WithMatchKeywords(anyKeyword, allKeyword uint64)
 // - WithProperty(p EnableProperty)
+//
+// Other options are ignored.
 func (s *Session) UpdateOptions(options ...Option) error {
 	for _, opt := range options {
 		opt(&s.config)


### PR DESCRIPTION
Sadly we can't use official gitlab-ci action cos it's based on linux container,
but we need mingw-64 and Windows headers even for linter. Moreover golangci-lint
works so bad on Windows so it seems currently easier to use cross-build container.

Tests on the other hand runs on the honest Windows VM.