### PR TITLE
Ignore errors in parsing single properties

### DIFF
--- a/event.go
+++ b/event.go
@@ -344,10 +344,9 @@ func (p *propertyParser) getPropertyValue(i int) (interface{}, error) {
 		} else {
 			value, err = p.parseSimpleType(i)
 		}
-		if err != nil {
-			return nil, err
+		if err == nil {
+			result[j] = value
 		}
-		result[j] = value
 	}
 
 	if int(C.PropertyIsArray(p.info, C.int(i))) == 1 {


### PR DESCRIPTION
Sometimes a single property will fail to parse but the rest of the event properties are valuable - it is important to keep going so we can get some data back if possible. An example for this is the provider `{22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716}` Microsoft-Windows-Kernel-Process with event id 1 (process create). Without this change it fails to return any event properties but actually it just fails to parse the flags.