### PR TITLE
[SAMPLE] Fix Pointer alignment check when using -race

### DIFF
--- a/event.go
+++ b/event.go
@@ -518,6 +518,6 @@ func createUTF16String(ptr uintptr, len int) string {
 	if len == 0 {
 		return ""
 	}
-	bytes := unsafe.Slice(ptr, len)
+	bytes := unsafe.Slice(unsafe.Pointer(ptr), len)
 	return windows.UTF16ToString(bytes)
 }

--- a/event.go
+++ b/event.go
@@ -507,17 +507,12 @@ func stampToTime(quadPart C.LONGLONG) time.Time {
 }
 
 // Creates UTF16 string from raw parts.
-//
-// Actually in go we have no way to make a slice from raw parts, ref:
-// - https://github.com/golang/go/issues/13656
-// - https://github.com/golang/go/issues/19367
-// So the recommended way is "a fake cast" to the array with maximal len
-// with a following slicing.
 // Ref: https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
 func createUTF16String(ptr uintptr, len int) string {
 	if len == 0 {
 		return ""
 	}
-	bytes := unsafe.Slice(unsafe.Pointer(ptr), len)
-	return windows.UTF16ToString(bytes)
+	bytes := unsafe.Slice((*uint16)(unsafe.Pointer(ptr)), len)
+	ts := windows.UTF16ToString(bytes)
+      return ts
 }

--- a/event.go
+++ b/event.go
@@ -518,6 +518,6 @@ func createUTF16String(ptr uintptr, len int) string {
 	if len == 0 {
 		return ""
 	}
-	bytes := (*[1 << 29]uint16)(unsafe.Pointer(ptr))[:len:len]
+	bytes := unsafe.Slice(ptr, len)
 	return windows.UTF16ToString(bytes)
 }

--- a/event.go
+++ b/event.go
@@ -513,6 +513,5 @@ func createUTF16String(ptr uintptr, len int) string {
 		return ""
 	}
 	bytes := unsafe.Slice((*uint16)(unsafe.Pointer(ptr)), len)
-	ts := windows.UTF16ToString(bytes)
-      return ts
+	return windows.UTF16ToString(bytes)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/bi-zone/etw
+module github.com/lcostantino/etw
 
-go 1.13
+go 1.18
 
 require (
 	github.com/Microsoft/go-winio v0.4.14

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bi-zone/etw
+module github.com/lcostantino/etw
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lcostantino/etw
+module github.com/bi-zone/etw
 
 go 1.18
 

--- a/session.go
+++ b/session.go
@@ -54,7 +54,7 @@ type Session struct {
 	guid     windows.GUID
 	config   SessionOptions
 	callback EventCallback
-    contextKey *uint32
+        contextKey *uint32
 	etwSessionName []uint16
 	hSession       C.TRACEHANDLE
 	propertiesBuf  []byte


### PR DESCRIPTION
This is just a sample PR, since actually the uint32 can be improved.

Basically it does 2 things:

1- Bump version to 1.18 (at least should be 1.17 to use unsafe.Slice)
2- Remove panic from runtime ptr check when using -race flag.


Sample error:

fatal error: checkptr: pointer arithmetic computed bad pointer value

goroutine 22 [running]:
runtime.throw({0x903beb?, 0x4083ed?})
        C:/Program Files/Go/src/runtime/panic.go:992 +0x76 fp=0xc00008bc60 sp=0xc00008bc30 pc=0x438336
runtime.checkptrArithmetic(0xc000016070?, {0x0?, 0xc00008bcc8?, 0x40efc7?})
        C:/Program Files/Go/src/runtime/checkptr.go:53 +0xbb fp=0xc00008bc90 sp=0xc00008bc60 pc=0x4085bb
github.com/bi-zone/etw.(*Session).processEvents.func1(0xc00022a360, 0x1)
        C:/Users/lcostant/go/pkg/mod/github.com/bi-zone/etw@v0.0.0-20210519083747-fe9042eb0ea8/session.go:324 +0x7e fp=0xc00008bcd8 sp=0xc00008bc90 pc=0x75295e
github.com/bi-zone/etw.(*Session).processEvents(0xc00022a360?, 0x0?)
        C:/Users/lcostant/go/pkg/mod/github.com/bi-zone/etw@v0.0.0-20210519083747-fe9042eb0ea8/session.go:324 +0x11a fp=0xc00008bd98 sp=0xc00008bcd8 pc=0x75273a
github.com/bi-zone/etw.(*Session).Process(0xc00022a360, 0xc000040000)
        C:/Users/lcostant/go/pkg/mod/github.com/bi-zone/etw@v0.0.0-20210519083747-fe9042eb0ea8/session.go:126 +0x1c7 fp=0xc00008be80 sp=0xc00008bd98 pc=0x751ae7
github.com/lcostantino/Panoptes/panoptes.(*Client).Start.func1({0xc0000c0360, 0x26}, {0xc0000a9535, 0xb}, {0xbb60b0, 0x0, 0x0})
        C:/Users/lcostant/repos/panoptes/panoptes/client.go:81 +0x265 fp=0xc00008bf58 sp=0xc00008be80 pc=0x754ea5
github.com/lcostantino/Panoptes/panoptes.(*Client).Start.func4()
        C:/Users/lcostant/repos/panoptes/panoptes/client.go:110 +0xaf fp=0xc00008bfe0 sp=0xc00008bf58 pc=0x754bef
runtime.goexit()
        C:/Program Files/Go/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc00008bfe8 sp=0xc00008bfe0 pc=0x467001
created by github.com/lcostantino/Panoptes/panoptes.(*Client).Start
        C:/Users/lcostant/repos/panoptes/panoptes/client.go:79 +0x16e

goroutine 1 [chan receive]:
main.main()
        C:/Users/lcostant/repos/panoptes/app/panoptes.go:291 +0x141a