### PR TITLE
fix(session): allow compiling for ARM64

### DIFF
--- a/session.go
+++ b/session.go
@@ -14,8 +14,10 @@ package etw
 	#cgo LDFLAGS: -ltdh
 
 	#include "session.h"
+	#include "stdint.h"
 */
 import "C"
+
 import (
 	"fmt"
 	"math/rand"
@@ -322,7 +324,10 @@ func (s *Session) processEvents(callbackContextKey uintptr) error {
 		(C.LPWSTR)(unsafe.Pointer(&s.etwSessionName[0])),
 		(C.PVOID)(callbackContextKey),
 	)
-	if C.INVALID_PROCESSTRACE_HANDLE == traceHandle {
+	// Based on the API docs:
+	// (INVALID_PROCESSTRACE_HANDLE is equivalent to (UINT64)UINTPTR_MAX.)
+	// Ref: https://learn.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-opentracea
+	if uint64(C.UINTPTR_MAX) == uint64(traceHandle) {
 		return fmt.Errorf("OpenTraceW failed; %w", windows.GetLastError())
 	}
 


### PR DESCRIPTION
Without this patch the compilation fails with

`session.go:325:5: (_Ciconst_INVALID_PROCESSTRACE_HANDLE) (untyped int constant -1) overflows uint64`

Used llvm-mingw/bin/aarch64-w64-mingw32-gcc